### PR TITLE
feat: add palette_overrides config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Port of the VS Code theme, [Vesper](https://github.com/raunofreiberg/vesper)
 <br/>
 <br/>
 
-![preview](./assets/preview.png) 
+![preview](./assets/preview.png)
 
 <br/>
 <br/>
@@ -43,6 +43,7 @@ require('vesper').setup({
         variables = true, -- Boolean: Italicizes variables
     },
     overrides = {}, -- A dictionary of group names, can be a function returning a dictionary or a table.
+  palette_overrides = {}
 })
 ```
 
@@ -70,4 +71,4 @@ Take a look at the [Development Guide](./DEVELOPMENT_GUIDE.md)
 
 ## License
 
-[MIT License](LICENSE) 
+[MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require('vesper').setup({
         variables = true, -- Boolean: Italicizes variables
     },
     overrides = {}, -- A dictionary of group names, can be a function returning a dictionary or a table.
-  palette_overrides = {}
+    palette_overrides = {}
 })
 ```
 

--- a/lua/vesper/config.lua
+++ b/lua/vesper/config.lua
@@ -10,6 +10,7 @@ local config = {
 			bufferline = false,
 		},
 		overrides = {},
+		palette_overrides = {},
 	},
 }
 

--- a/lua/vesper/init.lua
+++ b/lua/vesper/init.lua
@@ -27,6 +27,10 @@ local function set_terminal_colors()
 end
 
 local function set_groups()
+	for color, hex in pairs(config.palette_overrides) do
+		colors[color] = hex
+	end
+
 	local bg = config.transparent and "NONE" or colors.bg
 	local diff_add = utils.shade(colors.green, 0.5, colors.bg)
 	local diff_delete = utils.shade(colors.red, 0.5, colors.bg)
@@ -279,10 +283,10 @@ local function set_groups()
 		["@lsp.typemod.function.readonly"] = { link = "@function" },
 	}
 
-  -- integrations
-  groups = vim.tbl_extend("force", groups, cmp.highlights())
+	-- integrations
+	groups = vim.tbl_extend("force", groups, cmp.highlights())
 
-  -- overrides
+	-- overrides
 	groups =
 		vim.tbl_extend("force", groups, type(config.overrides) == "function" and config.overrides() or config.overrides)
 


### PR DESCRIPTION
I added palette_overrides property on setup settings to make theme customization easier.
Personally, I needed it bc I was trying to replicate [Vesper++](https://marketplace.visualstudio.com/items?itemName=Obstinate.vesper-pp) colorscheme